### PR TITLE
Section Dockerfile, separate 'core' packages from user ones.

### DIFF
--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -1,8 +1,9 @@
+# Dockerfile for Data100 User Image for Spring 2018
+
+# Basic Ubuntu image creation and setup
 FROM ubuntu:17.10
 
-ENV CONDA_PREFIX /srv/conda
-ENV PATH ${CONDA_PREFIX}/bin:$PATH
-
+# Core package setup
 RUN apt-get update && \
 	apt-get install --yes \
 		locales \
@@ -14,16 +15,27 @@ RUN apt-get update && \
 		curl \
 		wget \
 		vim \
+		;
+
+# Other packages for user convenience and Data100 usage
+# Install these without 'recommended' packages to keep image smaller.
+RUN apt-get install --no-install-recommends --yes \
+		screen \
+		tmux \
+		emacs-nox \
+		nano \
+		mc \
+		htop \
+		postgresql-client \
 		# for nbconvert
 		pandoc \
 		texlive-xetex \
 		texlive-fonts-recommended \
 		texlive-generic-recommended \
-		postgresql-client \
-		tmux \
-		mc \
-		nano \
-		emacs-nox
+		;
+
+# Keep image size at a minimum
+RUN apt-get clean
 
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -32,18 +44,25 @@ ENV LANGUAGE en_US.UTF-8
 RUN echo "${LC_ALL} UTF-8" > /etc/locale.gen && \
 	locale-gen
 
+####################################################################
+# Prepare container user (jovyan), with paths that Conda will use
+
+ENV CONDA_PREFIX /srv/conda
+ENV PATH ${CONDA_PREFIX}/bin:$PATH
+
 RUN adduser --disabled-password --gecos "Default Jupyter user" jovyan
 
 RUN install -d -o jovyan -g jovyan ${CONDA_PREFIX}
 
 WORKDIR /home/jovyan
 
-RUN apt-get clean
-
 USER jovyan
 
+####################################################################
+# Download, install and configure the Conda environment
+
 RUN curl -o /tmp/miniconda.sh \
-	https://repo.continuum.io/miniconda/Miniconda3-4.3.30-Linux-x86_64.sh 
+	https://repo.continuum.io/miniconda/Miniconda3-4.3.31-Linux-x86_64.sh 
 
 # Install miniconda
 RUN bash /tmp/miniconda.sh -b -u -p ${CONDA_PREFIX}
@@ -74,4 +93,6 @@ RUN pip install psycopg2==2.7.3.2
 # Useful for debugging any issues with conda
 RUN conda info -a
 
+####################################################################
+# Make JupyterHub ports visible
 EXPOSE 8888


### PR DESCRIPTION
Put `--no-install-recommends` only on user-oriented packages, as it's easy
to miss something important for more system-oriented ones.

I basically ended up debugging the same issue @ryanlovett had to with `ca-certificates` (sorry Ryan! :). Also tried to break up the file into sections for both readability and quicker rebuilding when testing locally.