### PR TITLE
Update env.yml to match website for students.

### DIFF
--- a/user-image/environment.yml
+++ b/user-image/environment.yml
@@ -13,7 +13,6 @@ dependencies:
 - entrypoints=0.2.3
 - expat=2.2.5
 - flake8=3.5.0
-- gettext=0.19.8.1
 - html5lib=1.0.1
 - hypothesis=3.38.5
 - ipykernel=4.7.0
@@ -32,7 +31,6 @@ dependencies:
 - mistune=0.8.3
 - nbconvert=5.3.1
 - nbformat=4.4.0
-- ncurses=6.0
 - networkx=2.0
 - notebook=5.3.1
 - numpy=1.12.1
@@ -67,11 +65,11 @@ dependencies:
 - simplegeneric=0.8.1
 - sip=4.18.1
 - six=1.11.0
+- sqlalchemy=1.2.1
 - sqlite=3.20.1
 - statsmodels=0.8.0
 - sympy=1.1.1
 - tensorflow=1.1.0
-- terminado=0.8.1
 - toolz=0.9.0
 - tornado=4.5.3
 - traitlets=4.3.2


### PR DESCRIPTION
In particular, remove unix-only explicit dependencies that were causing trouble
on Windows. They will be OK on linux, as they get pulled implicitly by other
packages, but we don't want to list them as hard deps for the environment.

Also, reinstate the sqlalchemy dep that got accidentally deleted as part of
reverting a bigger PR.