### PR TITLE
Update JupyterLab to 0.31.2

### DIFF
--- a/user-image/environment.yml
+++ b/user-image/environment.yml
@@ -80,7 +80,7 @@ dependencies:
 - pip:
   - colorlover==0.2.1
   - cufflinks==0.12.1
-  - jupyterlab==0.31.1
+  - jupyterlab==0.31.2
   - oauthlib==2.0.6
   - requests-oauthlib==0.8.0
   - tweepy==3.5.0


### PR DESCRIPTION
Since lab is purely a convenience for our team, it's safe to upgrade it. We won't touch other parts of the env unless we find a serious bug.