### PR TITLE
Upgrade notebook to 5.4.0 to fix issue 3248

### DIFF
--- a/user-image/environment.yml
+++ b/user-image/environment.yml
@@ -32,7 +32,7 @@ dependencies:
 - nbconvert=5.3.1
 - nbformat=4.4.0
 - networkx=2.0
-- notebook=5.3.1
+- notebook=5.4.0
 - numpy=1.12.1
 - pandas=0.22
 - pandoc=1.19.2.1


### PR DESCRIPTION
Unfortunately, the 5.3.1 release of the notebook shipped with a [nasty bug](https://github.com/jupyter/notebook/issues/3248). A [fix was released in 5.4.0](https://github.com/jupyter/notebook/pull/3264), so we should update.

I'll make a post on Piazza as well informing students running things locally to update.