### PR TITLE
Update nbgrader.

### DIFF
--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -95,7 +95,7 @@ RUN pip install psycopg2==2.7.3.2
 RUN jupyter serverextension enable --sys-prefix --py jupyterlab
 
 #RUN pip install nbgrader==0.5.4
-RUN pip install git+git://github.com/berkeley-dsep-infra/nbgrader.git@e48d20c
+RUN pip install git+git://github.com/berkeley-dsep-infra/nbgrader.git@85ec36c
 RUN jupyter nbextension install --sys-prefix --py nbgrader
 RUN jupyter nbextension enable --sys-prefix --py nbgrader
 RUN jupyter serverextension enable --sys-prefix --py nbgrader


### PR DESCRIPTION
We want it to skip filesystem checks when strict mode is enabled.