### PR TITLE
adding java support

### DIFF
--- a/user-image/Dockerfile
+++ b/user-image/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get install --no-install-recommends --yes \
 		texlive-xetex \
 		texlive-fonts-recommended \
 		texlive-generic-recommended \
+		default-jdk \
 		;
 
 # Keep image size at a minimum


### PR DESCRIPTION
This will allow us to run Spark using the following sequence of commands from within a jupyter notebook.  (I have tested it locally in this Docker image):

```python
# Download and extract tar
!curl -O https://d3kbcqa49mib13.cloudfront.net/spark-2.2.0-bin-hadoop2.7.tgz
!tar -xvf spark-2.2.0-bin-hadoop2.7.tgz

# Installing spark finding tools
!pip install findspark

# Initialize Spark
import os
import findspark
os.environ["PYSPARK_PYTHON"] = "python3"
findspark.init("spark-2.2.0-bin-hadoop2.7",)

# Launch Spark Session
from pyspark.sql import SparkSession, Column, Row, functions as F 
spark = (
    SparkSession.builder
        .master("local[*]")
        .appName("LectureExample")
        .getOrCreate()
)
sc = spark.sparkContext

# Test Spark 
numbers = sc.parallelize(range(32))
numbers.sum()
```

